### PR TITLE
Removing the jaMod snapshot dependency.  This version has been released.

### DIFF
--- a/camel-jamod/pom.xml
+++ b/camel-jamod/pom.xml
@@ -14,9 +14,9 @@
         defining endpoints to Modbus devices through the use of Jamod, a 100%
         Java library implementation of the Modbus protocol.
     </description>
-    
+
     <url>https://github.com/sworisbreathing/camel-jamod</url>
-    
+
     <scm>
         <url>https://github.com/sworisbreathing/camel-jamod</url>
         <connection>scm:git:git://github.com/sworisbreathing/camel-jamod.git</connection>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.jamod</artifactId>
-            <version>1.2_1-SNAPSHOT</version>
+            <version>1.2_1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -68,12 +68,12 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>  
-            <version>1.8.5</version> 
+            <artifactId>mockito-core</artifactId>
+            <version>1.8.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <repositories>
         <repository>
             <id>apache.snapshots</id>
@@ -167,7 +167,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>github-site-publish</id>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -6,7 +6,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Camel-Jamod :: Demo :: POM</name>
-    
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -14,37 +14,37 @@
                 <artifactId>camel-jamod</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.servicemix.bundles</groupId>
                 <artifactId>org.apache.servicemix.bundles.jamod</artifactId>
-                <version>1.2_1-SNAPSHOT</version>
+                <version>1.2_1</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.6.4</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.0.2</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-core</artifactId>
                 <version>2.8.5</version>
             </dependency>
-            
+
         </dependencies>
     </dependencyManagement>
-    
+
     <modules>
         <module>demo-device</module>
         <module>demo-routes</module>
-    <module>demo-echo</module>
-  </modules>
+        <module>demo-echo</module>
+    </modules>
 </project>


### PR DESCRIPTION
Sorry, looks like my indents are off...

I noticed that the 1.2_1 release version is available on the public repo: http://mvnrepository.com/artifact/org.apache.servicemix.bundles/org.apache.servicemix.bundles.jamod/1.2_1

I rolled the dependency management section to reflect this.
